### PR TITLE
Troubleshoot local preview build error

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -56,10 +56,9 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = 5000;
+  // Serve the app on the provided PORT (for cloud environments) or default to 5000
+  // This serves both the API and the client.
+  const port = Number(process.env.PORT) || 5000;
   server.listen({
     port,
     host: "0.0.0.0",


### PR DESCRIPTION
Update server to use `PORT` environment variable to fix preview build in Lovable.

The app was hardcoding port 5000, preventing Lovable from detecting a healthy preview when it assigned a dynamic port via the `PORT` environment variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-36d5b9ec-fdba-4388-95b7-c5c6b3b0b389">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36d5b9ec-fdba-4388-95b7-c5c6b3b0b389">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

